### PR TITLE
Adding getRole permission in schema and user agent suffix in SCClient…

### DIFF
--- a/aws-servicecatalog-serviceaction/aws-servicecatalog-serviceaction.json
+++ b/aws-servicecatalog-serviceaction/aws-servicecatalog-serviceaction.json
@@ -75,7 +75,8 @@
     "create": {
       "permissions": [
         "servicecatalog:CreateServiceAction",
-        "ssm:DescribeDocument"
+        "ssm:DescribeDocument",
+        "iam:GetRole"
       ]
     },
     "read": {
@@ -85,7 +86,8 @@
     },
     "update": {
       "permissions": [
-        "servicecatalog:UpdateServiceAction"
+        "servicecatalog:UpdateServiceAction",
+        "iam:GetRole"
       ]
     },
     "delete": {

--- a/aws-servicecatalog-serviceaction/resource-role.yaml
+++ b/aws-servicecatalog-serviceaction/resource-role.yaml
@@ -23,6 +23,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "iam:GetRole"
                 - "servicecatalog:CreateServiceAction"
                 - "servicecatalog:DeleteServiceAction"
                 - "servicecatalog:DescribeServiceAction"

--- a/aws-servicecatalog-serviceaction/src/main/java/software/amazon/servicecatalog/SCClientBuilder.java
+++ b/aws-servicecatalog-serviceaction/src/main/java/software/amazon/servicecatalog/SCClientBuilder.java
@@ -1,13 +1,23 @@
 package software.amazon.servicecatalog;
 
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.services.servicecatalog.ServiceCatalogClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
+import static software.amazon.awssdk.core.client.config.SdkAdvancedClientOption.USER_AGENT_SUFFIX;
+
 public class SCClientBuilder {
+    private static final String CFN_USER_AGENT_SUFFIX = "CFN_Resource_Generated";
+
     public static ServiceCatalogClient getClient() {
+        final ClientOverrideConfiguration overrideConfiguration = ClientOverrideConfiguration
+                .builder()
+                .putAdvancedOption(USER_AGENT_SUFFIX, CFN_USER_AGENT_SUFFIX)
+                .build();
         return ServiceCatalogClient
                 .builder()
                 .httpClient(LambdaWrapper.HTTP_CLIENT)
+                .overrideConfiguration(overrideConfiguration)
                 .build();
     }
 }

--- a/aws-servicecatalog-serviceactionassociation/src/main/java/software/amazon/servicecatalog/SCClientBuilder.java
+++ b/aws-servicecatalog-serviceactionassociation/src/main/java/software/amazon/servicecatalog/SCClientBuilder.java
@@ -1,14 +1,23 @@
 package software.amazon.servicecatalog;
 
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.services.servicecatalog.ServiceCatalogClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
+import static software.amazon.awssdk.core.client.config.SdkAdvancedClientOption.USER_AGENT_SUFFIX;
+
 public class SCClientBuilder {
+    private static final String CFN_USER_AGENT_SUFFIX = "CFN_Resource_Generated";
 
     public static ServiceCatalogClient getClient() {
+        final ClientOverrideConfiguration overrideConfiguration = ClientOverrideConfiguration
+                .builder()
+                .putAdvancedOption(USER_AGENT_SUFFIX, CFN_USER_AGENT_SUFFIX)
+                .build();
         return ServiceCatalogClient
                 .builder()
                 .httpClient(LambdaWrapper.HTTP_CLIENT)
+                .overrideConfiguration(overrideConfiguration)
                 .build();
     }
 }


### PR DESCRIPTION
*Description of changes:* We need getRole permission to allow customer to assume custom roles while creating/updating service action. Also, we need user-agent suffix so that in reporting we can distinguish the calls from CLI vs Console vs CFN.

*Testing:* pre-commit run --all-files, mvn clean install

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
